### PR TITLE
Fix inconsistent label to integer mapping

### DIFF
--- a/fizyr_keras_retinanet.ipynb
+++ b/fizyr_keras_retinanet.ipynb
@@ -323,7 +323,8 @@
         "  writer.writerows(annotations)\n",
         "\n",
         "with open(CLASSES_FILE, 'w') as f:\n",
-        "  for i, line in enumerate(classes):\n",
+        "  # sort for consistent labels across runs",
+        "  for i, line in enumerate(sorted(classes)):\n",
         "    f.write('{},{}\\n'.format(line,i))"
       ],
       "execution_count": 0,


### PR DESCRIPTION
Iteration order over a set is arbitrary, which resulted in different integers assigned to labels each run. In case where the dataset is dynamically downloaded from Drive each time, e. g. for resuming training, this issue caused significant noise in labels. Sorting the set of labels before iterating over it solves the issue.